### PR TITLE
Allow to pass a custom set of rules and build a response object. r=jkerim

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -71,16 +71,19 @@ const metadataRules = {
   image_url: imageRules,
   title: titleRules,
   type: typeRules,
-  url: canonicalUrlRules,
+  url: canonicalUrlRules
 };
 
 
-function getMetadata(doc) {
+function getMetadata(doc, rules) {
   const metadata = {};
+  const ruleSet = rules || metadataRules;
 
-  Object.keys(metadataRules).map(metadataKey => {
-    const metadataRule = metadataRules[metadataKey];
-    metadata[metadataKey] = metadataRule(doc);
+  Object.keys(ruleSet).map(metadataKey => {
+    const metadataRule = ruleSet[metadataKey];
+    metadata[metadataKey] = typeof metadataRule === 'function' ?
+      metadataRule(doc) :
+      getMetadata(doc, metadataRule);
   });
 
   return metadata;

--- a/tests/getMetadata.test.js
+++ b/tests/getMetadata.test.js
@@ -1,6 +1,6 @@
 // Tests for parse.js
 const {assert} = require('chai');
-const {getMetadata} = require('../parser');
+const {getMetadata, metadataRules} = require('../parser');
 const {stringToDom} = require('./test-utils');
 
 describe('Get Metadata Tests', function() {
@@ -34,6 +34,47 @@ describe('Get Metadata Tests', function() {
     assert.equal(metadata.title, sampleTitle, `Unable to find ${sampleTitle} in ${sampleHtml}`);
     assert.equal(metadata.type, sampleType, `Unable to find ${sampleType} in ${sampleHtml}`);
     assert.equal(metadata.url, sampleUrl, `Unable to find ${sampleUrl} in ${sampleHtml}`);
+  });
+
+  it('allows custom rules', () => {
+    const doc = stringToDom(sampleHtml);
+    const rules = {
+      title: metadataRules.title,
+      description: metadataRules.description
+    };
+
+    const metadata = getMetadata(doc, rules);
+    assert.equal(metadata.title, sampleTitle, 'Error finding title');
+    assert.equal(metadata.description, sampleDescription, 'Error finding description');
+    assert.equal(Object.keys(metadata).length, 2);
+  });
+
+  it('allows to create groups of rules', () => {
+    const doc = stringToDom(sampleHtml);
+    const rules = {
+      openGraph: {
+        title: metadataRules.title,
+        description: metadataRules.description,
+        type: metadataRules.type,
+        url: metadataRules.url
+      },
+      media: {
+        icon: metadataRules.icon_url,
+        image: metadataRules.image_url
+      }
+    };
+
+    const metadata = getMetadata(doc, rules);
+    assert.isObject(metadata.openGraph);
+    assert.isObject(metadata.media);
+
+    assert.equal(metadata.openGraph.title, sampleTitle, 'Error finding title');
+    assert.equal(metadata.openGraph.description, sampleDescription, 'Error finding description');
+    assert.equal(metadata.openGraph.type, sampleType, 'Error finding type');
+    assert.equal(metadata.openGraph.url, sampleUrl, 'Error finding url');
+
+    assert.equal(metadata.media.icon, sampleIcon, 'Error finding icon');
+    assert.equal(metadata.media.image, sampleImage, 'Error finding image');
   });
 
 });


### PR DESCRIPTION
This PR allows you to pass a custom set of rules to the `getMetadata` function, but also allow you to organize the results in an object.

For example:
```javascript
const {getMetadata, metadataRules} = require('./parser');
const rules = {
      basic: {
          title: metadataRules.title,
          description: metadataRules.description
    }
};
const metadata = getMetadata(rules);
```

Will use just those 2 rules and organize the response in the structure provided:
```json
{
    "basic": {
        "title": "Some title",
        "description": "Some description"
    }
}
```
