### PR TITLE
Switch to babel-cli and update ESLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ coverage
 # nyc test coverage
 .nyc_output
 
+# babel generated files
+client
+
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Page Metadata Parser
-A Javascript library for parsing metadata in web pages.
+A JavaScript library for parsing metadata in web pages.
 
 [![CircleCI](https://circleci.com/gh/mozilla/page-metadata-parser.svg?style=svg)](https://circleci.com/gh/mozilla/page-metadata-parser)
 

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "fathom-web": "^1.1.2"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
+    "babel-cli": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
     "domino": "^1.0.25",
-    "eslint": "^2.13.1",
+    "eslint": "^3.6.1",
     "eslint-plugin-mozilla": "^0.0.3",
     "istanbul": "^0.4.4",
     "istanbul-instrumenter-loader": "^0.2.0",
@@ -46,10 +46,11 @@
   },
   "scripts": {
     "cover": "cat ./coverage/lcov/lcov.info | coveralls",
+    "lint": "eslint .",
+    "pretest": "npm run lint",
     "tdd": "npm run test:karma -- --no-single-run",
     "test": "npm-run-all test:*",
     "test:karma": "karma start",
-    "test:lint": "eslint .",
     "test:mocha": "istanbul cover _mocha --report lcovonly -- tests/*.test.js -R spec",
     "clientize": "webpack"
   }


### PR DESCRIPTION
Ref: https://github.com/mozilla/page-metadata-parser/pull/68#issuecomment-249721026,

Fixes the following warning when installing the dependencies via `npm install`:

> npm WARN deprecated babel@6.5.2: Babel's CLI commands have been moved from the babel package to the babel-cli package
