### PR TITLE
Adds babel-core to satisfy missing webpack dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "babel": "^6.5.2",
+    "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.14.0",
@@ -51,6 +52,6 @@
     "test:karma": "karma start",
     "test:lint": "eslint .",
     "test:mocha": "istanbul cover _mocha --report lcovonly -- tests/*.test.js -R spec",
-    "clientize": "webpack"
+    "clientize": "webpack --optimize-minimize --optimize-dedupe"
   }
 }


### PR DESCRIPTION
I tried to run the `npm run clientize` command today from the 0.4.2 release but it seems that `babel-core` is required for webpack to run and is missing from package.json. This patch adds it (back?) in along with a revised webpack command to spit out an optimized version (170KB) of the bundled JS.