### PR TITLE
Get provider name from og:site_name if available

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -126,6 +126,12 @@ const metadataRules = {
       (url, context) => makeUrlAbsolute(context.url, url)
     ]
   },
+
+  provider: {
+    rules: [
+      ['meta[property="og:site_name"]', node => node.element.getAttribute('content')]
+    ]
+  },
 };
 
 function getMetadata(doc, url, rules) {
@@ -148,8 +154,7 @@ function getMetadata(doc, url, rules) {
     metadata.url = url;
   }
 
-  metadata.provider = '';
-  if(url) {
+  if(url && !metadata.provider) {
     metadata.provider = getProvider(url);
   }
 

--- a/tests/getMetadata.test.js
+++ b/tests/getMetadata.test.js
@@ -33,6 +33,7 @@ describe('Get Metadata Tests', function() {
   const sampleTitle = 'Page Title';
   const sampleType = 'article';
   const sampleUrl = 'http://www.example.com/';
+  const sampleProviderName = 'Example Provider';
 
   const sampleHtml = `
     <html>
@@ -45,6 +46,7 @@ describe('Get Metadata Tests', function() {
       <meta property="og:title" content="${sampleTitle}" />
       <meta property="og:type" content="${sampleType}" />
       <meta property="og:url" content="${sampleUrl}" />
+      <meta property="og:site_name" content="${sampleProviderName}" />
     </head>
     </html>
   `;
@@ -59,6 +61,7 @@ describe('Get Metadata Tests', function() {
     assert.equal(metadata.title, sampleTitle, `Unable to find ${sampleTitle} in ${sampleHtml}`);
     assert.equal(metadata.type, sampleType, `Unable to find ${sampleType} in ${sampleHtml}`);
     assert.equal(metadata.url, sampleUrl, `Unable to find ${sampleUrl} in ${sampleHtml}`);
+    assert.equal(metadata.provider, sampleProviderName, `Unable to find ${sampleProviderName} in ${sampleHtml}`);
   });
 
   it('uses absolute URLs when url parameter passed in', () => {
@@ -83,11 +86,34 @@ describe('Get Metadata Tests', function() {
   });
 
   it('adds a provider when URL passed in', () => {
+      const emptyHtml = `
+        <html>
+        <head>
+        </head>
+        </html>
+    `;
+
     const sampleProvider = 'example';
-    const doc = stringToDom(sampleHtml);
+    const doc = stringToDom(emptyHtml);
     const metadata = getMetadata(doc, sampleUrl);
 
     assert.equal(metadata.provider, sampleProvider, `Unable to find ${sampleProvider} in ${sampleUrl}`);
+  });
+
+  it('prefers open graph site name over URL based provider', () => {
+      const sampleProvider = 'OpenGraph Site Name';
+      const providerHtml = `
+        <html>
+        <head>
+          <meta property="og:site_name" content="${sampleProvider}" />
+        </head>
+        </html>
+    `;
+
+    const doc = stringToDom(providerHtml);
+    const metadata = getMetadata(doc, sampleUrl);
+
+    assert.equal(metadata.provider, sampleProvider, `Unable to find ${sampleProvider} in ${providerHtml}`);
   });
 
   it('uses default favicon when no favicon is found', () => {

--- a/tests/metadataRules.test.js
+++ b/tests/metadataRules.test.js
@@ -124,3 +124,14 @@ describe('Keywords Rule Tests', function() {
 
   ruleTests.map(([testName, testTag]) => ruleTest(testName, metadataRules.keywords, keywords, testTag));
 });
+
+describe('Provider Rule Tests', function() {
+  const provider = 'Example provider';
+
+  const ruleTests = [
+    ['og:type', `<meta property="og:site_name" content="${provider}" />`],
+  ];
+
+  ruleTests.map(([testName, testTag]) => ruleTest(testName, metadataRules.provider, provider, testTag));
+});
+


### PR DESCRIPTION
Issue #79 contains a list of potential sources for getting a 'provider name'.
However only og:site_name is the only reliable. The other options have slightly
different semantic meanings and therefore might return values that are not
suitable. Because of that this patch only adds support for og:site_name for now.