### PR TITLE
Bug 1435308 — Improve canonical link detection for AMP pages.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -142,6 +142,7 @@ const metadataRuleSets = {
 
   url: {
     rules: [
+      ['a.amp-canurl', element => element.getAttribute('href')],
       ['meta[property="og:url"]', element => element.getAttribute('content')],
       ['link[rel="canonical"]', element => element.getAttribute('href')],
     ],

--- a/tests/metadataRules.test.js
+++ b/tests/metadataRules.test.js
@@ -49,6 +49,7 @@ describe('Canonical URL Rule Tests', function() {
     ['og:url', `<meta property="og:url" content="${pageUrl}" />`],
     ['rel=canonical', `<link rel="canonical" href="${pageUrl}" />`],
     ['relative canonical', `<link rel="canonical" href="${relativeUrl}" />`],
+    ['amp-canurl', `<a class="amp-canurl" href="${pageUrl}" />`],
   ];
 
   ruleTests.map(([testName, testTag]) => ruleTest(testName, metadataRuleSets.url, pageUrl, testTag));


### PR DESCRIPTION
This PR adds a rule to the `url` ruleset to improve the retrieval of the correct canonical link. 

From our tests of AMP pages hosted on the `google.com` domain, the `rel` url provided by pages have often pointed to the AMP version of the page, but hosted on publications' own domain. This still are AMP page.

The additional rule retrieves the desktop version of the page.

[Link to Bug 1435308](https://bugzilla.mozilla.org/show_bug.cgi?id=1435308).