### PR TITLE
Prefer canonical URLs to open-graph URLs.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -143,8 +143,8 @@ const metadataRuleSets = {
   url: {
     rules: [
       ['a.amp-canurl', element => element.getAttribute('href')],
-      ['meta[property="og:url"]', element => element.getAttribute('content')],
       ['link[rel="canonical"]', element => element.getAttribute('href')],
+      ['meta[property="og:url"]', element => element.getAttribute('content')],
     ],
     defaultValue: (context) => context.url,
     processors: [

--- a/tests/metadataRules.test.js
+++ b/tests/metadataRules.test.js
@@ -53,6 +53,19 @@ describe('Canonical URL Rule Tests', function() {
   ];
 
   ruleTests.map(([testName, testTag]) => ruleTest(testName, metadataRuleSets.url, pageUrl, testTag));
+
+  const wrongPageUrl = 'http://example.com/incorrect-page.html';
+  const ruleOrderingTests = [
+    ['rel=canonical before og:url', `
+      <link rel="canonical" href="${pageUrl}"/>
+      <meta property="og:url" content="${wrongPageUrl}" />
+    `],
+    ['amp-canurl before rel=canonical', `
+      <a class="amp-canurl" href="${pageUrl}" />
+      <link rel="canonical" href=${wrongPageUrl}/>
+    `],
+  ];
+  ruleOrderingTests.map(([testName, testTag]) => ruleTest(testName, metadataRuleSets.url, pageUrl, testTag));
 });
 
 


### PR DESCRIPTION
The og:url definition is given as:

> The canonical URL of your object that will be used as its permanent ID in the graph

Since the Facebook graph is necessarily a subset of the open web, there are instances such that the page points to the closest graph node which is the wrong web page. 

Currently, github provides an example of this e.g. from the page [`https://github.com/artsy/eidolon/tree/master/Kiosk`](view-source:https://github.com/artsy/eidolon/tree/master/Kiosk) : 

```html
<link rel="canonical" href="https://github.com/artsy/eidolon/tree/master/Kiosk" data-pjax-transient="">
<meta content="https://github.com/artsy/eidolon" property="og:url">
```

This PR flips the order of the rules so that the `canonical` link is taken before the `og:url`. 

Original bug report: Firefox for iOS, [Bug 1439349](https://bugzilla.mozilla.org/show_bug.cgi?id=1439349).