### PR TITLE
Change description/icon/keywords metatag rules to be case insensitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "domino": "^1.0.25",
+    "domino": "^2.1.0",
     "eslint": "^2.13.1",
     "eslint-plugin-mozilla": "^0.0.3",
     "istanbul": "^0.4.4",

--- a/parser.js
+++ b/parser.js
@@ -65,7 +65,7 @@ const metadataRuleSets = {
   description: {
     rules: [
       ['meta[property="og:description"]', element => element.getAttribute('content')],
-      ['meta[name="description"]', element => element.getAttribute('content')],
+      ['meta[name="description" i]', element => element.getAttribute('content')],
     ],
   },
 
@@ -73,7 +73,7 @@ const metadataRuleSets = {
     rules: [
       ['link[rel="apple-touch-icon"]', element => element.getAttribute('href')],
       ['link[rel="apple-touch-icon-precomposed"]', element => element.getAttribute('href')],
-      ['link[rel="icon"]', element => element.getAttribute('href')],
+      ['link[rel="icon" i]', element => element.getAttribute('href')],
       ['link[rel="fluid-icon"]', element => element.getAttribute('href')],
       ['link[rel="shortcut icon"]', element => element.getAttribute('href')],
       ['link[rel="Shortcut Icon"]', element => element.getAttribute('href')],
@@ -117,7 +117,7 @@ const metadataRuleSets = {
 
   keywords: {
     rules: [
-      ['meta[name="keywords"]', element => element.getAttribute('content')],
+      ['meta[name="keywords" i]', element => element.getAttribute('content')],
     ],
     processors: [
       (keywords, context) => keywords.split(',').map((keyword) => keyword.trim())

--- a/tests/getMetadata.test.js
+++ b/tests/getMetadata.test.js
@@ -144,6 +144,26 @@ describe('Get Metadata Tests', function() {
     assert.equal(metadata.url, sampleUrl, `Unable to find ${sampleUrl} in ${JSON.stringify(metadata)}`);
   });
 
+  it('it fetches keywords, icon and description from uppercased metadata property titles', () => {
+    const relativeHtml = `
+      <html>
+      <head>
+        <meta name="Description" content="${sampleDescription}" />
+        <meta name="Keywords" content="${sampleTitle}" />
+        <link rel="Icon" href="/favicon.ico" />
+      </head>
+      </html>
+    `;
+
+    const doc = stringToDom(relativeHtml);
+    const metadata = getMetadata(doc, sampleUrl, metadataRuleSets);
+
+    assert.equal(metadata.icon, sampleIcon, `Unable to find ${sampleIcon} in ${relativeHtml}`);
+    assert.equal(metadata.description, sampleDescription, `Unable to find ${sampleDescription} in ${relativeHtml}`);
+    assert.equal(metadata.keywords, sampleTitle, `Unable to find ${sampleTitle} in ${relativeHtml}`);
+
+  });
+
   it('allows custom rules', () => {
     const doc = stringToDom(sampleHtml);
     const rules = {


### PR DESCRIPTION
When using the metadata parser across the web I noticed that some sites use a capitalized version of some meta tags. I've changed their rule implementation to be case insensitive. 

I've also upgraded Domino to the latest version. Otherwise it has trouble working with the case insensitive selector flag.